### PR TITLE
Change Logo Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 <body>
     <header>
         <div class="header-logo">
-            <a href="https://koillection.github.io/koillection/">
+            <a href="https://koillection.github.io/">
                 <img class="logo" src="images/logo.svg" aria-label="Logo" width="45" height="45">
                 <span>Koillection</span>
             </a>


### PR DESCRIPTION
Clicking on the logo leads to https://koillection.github.io/koillection/ at the moment, which is a 404. Changed it to https://koillection.github.io/